### PR TITLE
API key regeneration implementation

### DIFF
--- a/src/main/java/com/tdei/auth/controller/authentication/Authentication.java
+++ b/src/main/java/com/tdei/auth/controller/authentication/Authentication.java
@@ -19,6 +19,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -95,5 +96,10 @@ public class Authentication implements IAuthentication {
     @Override
     public ResponseEntity<Boolean> resetCredentials(@Valid @RequestBody ResetCredentialModel resetCredentialModel) throws Exception {
         return ResponseEntity.ok(keycloakService.resetCredentials(resetCredentialModel));
+    }
+
+    @Override
+    public ResponseEntity<String> regenerateAPIKey(@RequestParam(name = "username") String username) throws Exception {
+        return ResponseEntity.ok(keycloakService.regenerateAPIKey(username));
     }
 }

--- a/src/main/java/com/tdei/auth/controller/authentication/contract/IAuthentication.java
+++ b/src/main/java/com/tdei/auth/controller/authentication/contract/IAuthentication.java
@@ -174,5 +174,18 @@ public interface IAuthentication {
             produces = {"application/json"},
             method = RequestMethod.POST)
     ResponseEntity<Boolean> resetCredentials(@Valid @RequestBody ResetCredentialModel resetCredentialModel) throws Exception;
+
+
+    @Operation(summary = "Regenerate API Key", description = "Regenerate API Key.  Returns the new API Key.",
+            tags = {"Authentication"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successful response - Returns the new API Key.", content = @Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "An server error occurred.", content = @Content)})
+    @RequestMapping(value = "regenerateAPIKey",
+            produces = {"text/plain"},
+            consumes = {"*"},
+            method = RequestMethod.POST)
+    ResponseEntity<String> regenerateAPIKey(@RequestParam(name = "username") String username) throws Exception;
 }
 

--- a/src/test/java/unit/auth/controller/authControllerTest.java
+++ b/src/test/java/unit/auth/controller/authControllerTest.java
@@ -38,7 +38,8 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @Tag("Unit")
 @ExtendWith(MockitoExtension.class)
@@ -451,5 +452,24 @@ public class authControllerTest {
         Set<ConstraintViolation<RegisterUser>> violations = validator.validate(registerUser);
         System.out.println(violations);
         assertFalse(violations.isEmpty());
+    }
+
+
+    @Test
+    @DisplayName("When regenerating API key for valid user, Expect to return new API key")
+    void regenerateAPIKeyValidUser() throws Exception {
+        doReturn("new_api_key").when(keycloakService).regenerateAPIKey(anyString());
+
+        var response = authController.regenerateAPIKey("test_username");
+
+        assertThat(response.getBody()).isEqualTo("new_api_key");
+    }
+
+    @Test
+    @DisplayName("When regenerating API key for non-existing user, Expect to throw ResourceNotFoundException")
+    void regenerateAPIKeyNonExistingUser() throws Exception {
+        doThrow(new ResourceNotFoundException("User not found")).when(keycloakService).regenerateAPIKey(anyString());
+
+        assertThrows(ResourceNotFoundException.class, () -> authController.regenerateAPIKey("test"));
     }
 }


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1722

## Changes Introduced  
- Introduces a new feature to regenerate API keys for users .
- Updated the test cases
- Tested **Impacted Areas for test cases**.

## Impacted Areas for Testing  
- New api /regenerateAPIKey to be verified 
- Post regeneration of api key , ensure old api key does not work and throws unauthorized error. 
- Future access should be made only from new api key
