### PR TITLE
Task 1680

### DIFF
--- a/src/main/java/com/tdei/auth/controller/authentication/Authentication.java
+++ b/src/main/java/com/tdei/auth/controller/authentication/Authentication.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.security.InvalidKeyException;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,7 +48,7 @@ public class Authentication implements IAuthentication {
     }
 
     @Override
-    public ResponseEntity<TokenResponse> authenticate(@Valid @RequestBody LoginModel loginModel) {
+    public ResponseEntity<TokenResponse> authenticate(@Valid @RequestBody LoginModel loginModel) throws TimeoutException {
         AccessTokenResponse accessTokenResponse = keycloakService.getUserToken(loginModel);
         TokenResponse token = TokenMapper.INSTANCE.fromAccessTokenResponse(accessTokenResponse);
         return ResponseEntity.ok(token);

--- a/src/main/java/com/tdei/auth/controller/authentication/contract/IAuthentication.java
+++ b/src/main/java/com/tdei/auth/controller/authentication/contract/IAuthentication.java
@@ -30,6 +30,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import java.security.InvalidKeyException;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 
 @Validated
 public interface IAuthentication {
@@ -114,7 +115,7 @@ public interface IAuthentication {
     @RequestMapping(value = "authenticate",
             produces = {"application/json"},
             method = RequestMethod.POST)
-    ResponseEntity<TokenResponse> authenticate(@Valid @RequestBody LoginModel loginModel);
+    ResponseEntity<TokenResponse> authenticate(@Valid @RequestBody LoginModel loginModel) throws TimeoutException;
 
 
     @Operation(summary = "Check user access", description = "Returns boolean flag if user satisfies the roles.",

--- a/src/main/java/com/tdei/auth/core/config/ApplicationProperties.java
+++ b/src/main/java/com/tdei/auth/core/config/ApplicationProperties.java
@@ -50,7 +50,8 @@ public class ApplicationProperties {
     @NoArgsConstructor
     public static class keycloakProperties {
         private String authServerUrl;
-        //private String userUrl;
+        private int connectionPoolSize;
+        private int connectionTimeout;
         private String realm;
         private String resource;
         private KeycloakCreds credentials;

--- a/src/main/java/com/tdei/auth/core/config/BeanConfig.java
+++ b/src/main/java/com/tdei/auth/core/config/BeanConfig.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.concurrent.TimeUnit;
+
 @Configuration
 public class BeanConfig {
 
@@ -23,7 +25,8 @@ public class BeanConfig {
                 .clientId(applicationProperties.getKeycloak().getResource())
                 .clientSecret(applicationProperties.getKeycloak().getCredentials().getSecret())
                 .resteasyClient(new ResteasyClientBuilder()
-                        .connectionPoolSize(10)
+                        .connectionPoolSize(applicationProperties.getKeycloak().getConnectionPoolSize())
+                        .connectTimeout(applicationProperties.getKeycloak().getConnectionTimeout(), TimeUnit.SECONDS)
                         .build()
                 )
                 .build();

--- a/src/main/java/com/tdei/auth/core/config/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tdei/auth/core/config/exception/handler/GlobalExceptionHandler.java
@@ -185,6 +185,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     }
 
+    @ExceptionHandler(GatewayTimeoutException.class)
+    protected ResponseEntity<Object> gatewayTimeoutException(GatewayTimeoutException ex, WebRequest request) {
+
+        List<String> details = new ArrayList<>();
+        details.add(ex.getMessage());
+
+        ApiError err = new ApiError(LocalDateTime.now(), HttpStatus.GATEWAY_TIMEOUT, "", details);
+
+        return ResponseEntityBuilder.build(err);
+
+    }
+
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleAll(Exception ex, WebRequest request) {
 

--- a/src/main/java/com/tdei/auth/core/config/exception/handler/exceptions/GatewayTimeoutException.java
+++ b/src/main/java/com/tdei/auth/core/config/exception/handler/exceptions/GatewayTimeoutException.java
@@ -1,0 +1,13 @@
+package com.tdei.auth.core.config.exception.handler.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
+public class GatewayTimeoutException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public GatewayTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tdei/auth/service/KeycloakService.java
+++ b/src/main/java/com/tdei/auth/service/KeycloakService.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.spec.SecretKeySpec;
-import javax.sql.DataSource;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
 import javax.xml.bind.DatatypeConverter;
@@ -49,8 +48,6 @@ public class KeycloakService implements IKeycloakService {
     private static SignatureAlgorithm signatureAlgorithm;
     private final Keycloak keycloakInstance;
     private final ApplicationProperties applicationProperties;
-    @Autowired
-    private DataSource dataSource;
     @Autowired
     private UserManagementRepository userManagementRepository;
 
@@ -121,7 +118,6 @@ public class KeycloakService implements IKeycloakService {
     }
 
     public AccessTokenResponse getUserToken(LoginModel person) throws TimeoutException {
-        System.out.println("Using DataSource: " + dataSource.getClass().getName());
 
         AccessTokenResponse token = null;
         try {

--- a/src/main/java/com/tdei/auth/service/KeycloakService.java
+++ b/src/main/java/com/tdei/auth/service/KeycloakService.java
@@ -31,12 +31,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.spec.SecretKeySpec;
+import javax.sql.DataSource;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
 import javax.xml.bind.DatatypeConverter;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @RequiredArgsConstructor
 @Service
@@ -45,7 +49,8 @@ public class KeycloakService implements IKeycloakService {
     private static SignatureAlgorithm signatureAlgorithm;
     private final Keycloak keycloakInstance;
     private final ApplicationProperties applicationProperties;
-
+    @Autowired
+    private DataSource dataSource;
     @Autowired
     private UserManagementRepository userManagementRepository;
 
@@ -75,6 +80,9 @@ public class KeycloakService implements IKeycloakService {
                     applicationProperties.getKeycloak().getCredentials().getSecret(),
                     accessToken);
             return Optional.of(user);
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error getting user by access token", e);
             throw new InvalidAccessTokenException("Invalid/Expired Access Token");
@@ -112,7 +120,9 @@ public class KeycloakService implements IKeycloakService {
         return satisfied;
     }
 
-    public AccessTokenResponse getUserToken(LoginModel person) {
+    public AccessTokenResponse getUserToken(LoginModel person) throws TimeoutException {
+        System.out.println("Using DataSource: " + dataSource.getClass().getName());
+
         AccessTokenResponse token = null;
         try {
             UsersResource usersResource = getUserInstance();
@@ -136,7 +146,8 @@ public class KeycloakService implements IKeycloakService {
                     .username(person.getUsername())
                     .password(person.getPassword())
                     .resteasyClient(new ResteasyClientBuilder()
-                            .connectionPoolSize(1)
+                            .connectionPoolSize(applicationProperties.getKeycloak().getConnectionPoolSize())
+                            .connectTimeout(applicationProperties.getKeycloak().getConnectionTimeout(), TimeUnit.SECONDS)
                             .build()
                     )
                     .build();
@@ -152,6 +163,9 @@ public class KeycloakService implements IKeycloakService {
         } catch (InvalidCredentialsException e) {
             log.error("Invalid credentials", e);
             throw new InvalidCredentialsException("Invalid Credentials");
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error authenticating the user", e);
             throw new InvalidCredentialsException("Invalid Credentials");
@@ -173,6 +187,9 @@ public class KeycloakService implements IKeycloakService {
             res.setExpiresIn(Math.round((Double) user.get("expires_in")));
             res.setRefreshExpiresIn(Math.round((Double) user.get("refresh_expires_in")));
             return res;
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error refreshing the token", e);
             throw new InvalidAccessTokenException("Invalid/Expired Access Token");
@@ -213,6 +230,9 @@ public class KeycloakService implements IKeycloakService {
             return false;
         } catch (IllegalArgumentException e) {
             return false;
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         }
         return true;
     }
@@ -241,6 +261,9 @@ public class KeycloakService implements IKeycloakService {
         } catch (NotFoundException e) {
             log.error("User not found", e);
             throw new ResourceNotFoundException("User not found");
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error resetting the password", e);
             throw new Exception("Error resetting the password");
@@ -296,6 +319,9 @@ public class KeycloakService implements IKeycloakService {
             } else if (createdUserRes.getStatus() == 409) {
                 throw new UserExistsException(userDto.getEmail().trim());
             }
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Failed registering the user", e);
             if (e instanceof UserExistsException)
@@ -321,6 +347,9 @@ public class KeycloakService implements IKeycloakService {
             if (userInfo.getAttributes() != null && userInfo.getAttributes().get("x-api-key") != null)
                 userProfile.setApiKey(userInfo.getAttributes().get("x-api-key").stream().findFirst().get());
             return userProfile;
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error fetching the user information", e);
             throw new Exception("Error fetching the user information");
@@ -346,6 +375,9 @@ public class KeycloakService implements IKeycloakService {
         } catch (NotFoundException e) {
             log.error("User not found", e);
             throw new ResourceNotFoundException("User not found");
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error triggering the email", e);
             throw new Exception("Error triggering the email");
@@ -379,6 +411,9 @@ public class KeycloakService implements IKeycloakService {
         } catch (NotFoundException e) {
             log.error("User not found", e);
             throw new ResourceNotFoundException("User not found");
+        } catch (ProcessingException ex) {
+            log.error("Connection timeout", ex);
+            throw new GatewayTimeoutException("Connection Timeout");
         } catch (Exception e) {
             log.error("Error regenerating the API key", e);
             throw new Exception("Error regenerating the API key");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ spring:
     username: "${SPRING_DATASOURCE_USERNAME}"
     url: "${SPRING_DATASOURCE_URL}"
     password: "${SPRING_DATASOURCE_PASSWORD}"
+    hikari:
+      maximum-pool-size: "${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE}"
+      connection-timeout: "${SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT}"
 spring-doc:
   swagger-ui:
     operationsSorter: alpha
@@ -29,6 +32,8 @@ Keycloak-client-endpoints:
   base-url: "${KEYCLOAK_CLIENT_ENDPOINTS_BASE_URL}"
   redirect-url: "${KEYCLOAK_CLIENT_ENDPOINTS_REDIRECT_URL}"
 keycloak:
+  connection-pool-size: "${KEYCLOAK_CONNECTION_POOL_SIZE}"
+  connection-timeout: "${KEYCLOAK_CONNECTION_TIMEOUT}"
   auth-server-url: "${KEYCLOAK_AUTH_SERVER_URL}"
   realm: tdei
   enabled: true

--- a/src/test/java/unit/auth/controller/authControllerTest.java
+++ b/src/test/java/unit/auth/controller/authControllerTest.java
@@ -35,6 +35,7 @@ import javax.validation.ValidatorFactory;
 import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -106,7 +107,7 @@ public class authControllerTest {
 
     @Test
     @DisplayName("When authenticating user with valid credentials, Expect to return HTTP Status 200 with TokenResponse details")
-    void authenticateTest() {
+    void authenticateTest() throws TimeoutException {
         //Arrange
         LoginModel loginModel = new LoginModel();
         loginModel.setUsername("test_username");
@@ -144,7 +145,7 @@ public class authControllerTest {
 
     @Test
     @DisplayName("When authenticating user with invalid credentials, Expect to throw InvalidCredentialsException")
-    void authenticateTest2() {
+    void authenticateTest2() throws TimeoutException {
         //Arrange
         LoginModel loginModel = new LoginModel();
         loginModel.setUsername("test_username");


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1680

## Changes Introduced  
- Caching the specific timeout errors from Keycloak server. 
- Configurable connection pool size and timeout. 
- Above changes are required for fine tuning the application while determining the rate limit of the system.
- No implementation logic changes involved.

## Impacted Areas for Testing  
- Auth api endpoints to be tested to ensure working as expected.  